### PR TITLE
update README for proper Apache2 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ root@wistar-build:~# mkdir -p /opt/wistar/media
 Clone the GitHub repo.
 
 ```      
-root@wistar-build:/opt/wistar# git clone https://github.com/juniper/wistar.git
+root@wistar-build:/opt/wistar# git clone https://github.com/juniper/wistar.git wistar-master
 ```
 
-Creat the SQL tables.
+Create the SQL tables.
 
 ```
 root@wistar-build:/opt/wistar# cd wistar-master/
@@ -87,9 +87,9 @@ Alternatively, you can configure a more robust web server such as Apache or ngin
 
 Here is how you can configure apache for use with wistar.
  ```
-root@wistar-build:~# apt-get install libapache2-mod-wsgi
+root@wistar-build:~# apt-get install apache2 libapache2-mod-wsgi
 root@wistar-build:~# cat /etc/apache2/sites-enabled/999-wistar.conf
-Define wistar_path /opt/wistar
+Define wistar_path /opt/wistar/wistar-master
 Listen 8080
 <VirtualHost *:8080>
 	WSGIScriptAlias / ${wistar_path}/wistar/wsgi.py
@@ -108,6 +108,13 @@ Listen 8080
 		</Files>
 	</Directory>
 </VirtualHost>
+```
+
+Grant the apache user permissions to the wistar directory and the apache/wistar log files:
+```
+root@wistar-build:~# chown -R www-data:www-data /opt/wistar
+root@wistar-build:~# chown -R www-data:www-data /var/log/apache2/wistar.log
+root@wistar-build:~# chown -R www-data:www-data /var/log/apache2/wistar_access.log
 ```
 
 Also, ensure the apache user is in the libvirtd group.

--- a/extras/999-wistar.conf
+++ b/extras/999-wistar.conf
@@ -1,4 +1,4 @@
-Define wistar_path /opt/wistar/wistar-app/
+Define wistar_path /opt/wistar/wistar-master/
 Listen 8080
 <VirtualHost *:8080>
    WSGIScriptAlias / ${wistar_path}/wistar/wsgi.py

--- a/extras/999-wistar.conf
+++ b/extras/999-wistar.conf
@@ -1,0 +1,19 @@
+Define wistar_path /opt/wistar/wistar-app/
+Listen 8080
+<VirtualHost *:8080>
+   WSGIScriptAlias / ${wistar_path}/wistar/wsgi.py
+   WSGIDaemonProcess wistar python-path=${wistar_path}
+   WSGIProcessGroup wistar
+   ErrorLog /var/log/apache2/wistar.log
+   CustomLog /var/log/apache2/wistar_access.log combined
+   Alias /static/ ${wistar_path}/common/static/
+
+   <Directory "${wistar_path}/common/static">
+   	Require all granted
+   </Directory>
+   <Directory ${wistar_path}>
+   	<Files wsgi.py>
+   		Require all granted
+   	</Files>
+   </Directory>
+</VirtualHost>

--- a/extras/install_wistar_ubuntu_14_pb.yml
+++ b/extras/install_wistar_ubuntu_14_pb.yml
@@ -138,9 +138,16 @@
       state: directory
       recurse: yes
 
-  - name: set permissions on wistar logfile
+  - name: set permissions on wistar errorlog
     file:
-      path: /var/log/wistar.log
+      path: /var/log/apache2/wistar.log
+      owner: www-data
+      group: www-data
+      state: file
+
+  - name: set permissions on wistar accesslog
+    file:
+      path: /var/log/apache2/wistar_access.log
       owner: www-data
       group: www-data
       state: file

--- a/extras/install_wistar_ubuntu_14_pb.yml
+++ b/extras/install_wistar_ubuntu_14_pb.yml
@@ -9,8 +9,10 @@
   become: true
 
   tasks:
-  - name: Update apt 1
-    apt: update_cache=yes
+  - name: Update all packages to the latest version
+    apt:
+      upgrade: dist
+      update_cache: yes
 
   - name: Install python-software-properties
     apt: name=python-software-properties state=present
@@ -90,7 +92,7 @@
       state: directory
   - name: Create Wistar directory structure 3
     file:
-      path: /opt/wistar/wistar-app
+      path: /opt/wistar/wistar-master
       state: directory
   - name: Create Wistar directory structure 4
     file:
@@ -109,15 +111,58 @@
     git:
       repo: https://github.com/Juniper/wistar.git
       depth: 1
-      dest: /opt/wistar/wistar-app/
-
-  - name: Set up Wistar to run at boot (HACK)
-    lineinfile:
-      create: no
-      dest: /etc/rc.local
-      insertbefore: exit 0
-      line: /opt/wistar/wistar-app/manage.py runserver 0.0.0.0:80 >>/var/log/wistar-stdout.log 2>&1 &
+      dest: /opt/wistar/wistar-master/
 
   - name: Create Wistar tables
-    command: /opt/wistar/wistar-app/manage.py migrate
+    command: /opt/wistar/wistar-master/manage.py migrate
 
+  - name: install apache2
+    apt:
+      name: "{{ item }}"
+      state: present
+    with_items:
+      - apache2
+      - libapache2-mod-wsgi
+
+  - name: enable the Apache2 module "wsgi"
+    apache2_module:
+      state: present
+      name: wsgi
+    notify: restart apache
+
+  - name: set permissions on wistar dir
+    file:
+      path: /opt/wistar
+      owner: www-data
+      group: www-data
+      state: directory
+      recurse: yes
+
+  - name: set permissions on wistar logfile
+    file:
+      path: /var/log/wistar.log
+      owner: www-data
+      group: www-data
+      state: file
+
+  - name: copy wistar config file to apache
+    copy:
+      src: 999-wistar.conf
+      dest: /etc/apache2/sites-available/999-wistar.conf
+
+  - name: enable wistar site in apache
+    copy:
+      src: /etc/apache2/sites-available/999-wistar.conf
+      dest: /etc/apache2/sites-enabled/999-wistar.conf
+      state: link
+    notify: restart apache
+
+  - name: add www-data to libvirt users
+    user:
+      name: www-data
+      groups: libvirtd
+      append: yes
+
+  handlers:
+    - name: restart apache
+      service: name=apache2 state=restarted

--- a/extras/install_wistar_ubuntu_16_pb.yml
+++ b/extras/install_wistar_ubuntu_16_pb.yml
@@ -141,7 +141,13 @@
   - name: copy wistar config file to apache
     copy:
       src: 999-wistar.conf
+      dest: /etc/apache2/sites-available/999-wistar.conf
+
+  - name: enable wistar site in apache
+    copy:
+      src: /etc/apache2/sites-available/999-wistar.conf
       dest: /etc/apache2/sites-enabled/999-wistar.conf
+      state: link
     notify: restart apache
 
   - name: add www-data to libvirt users

--- a/extras/install_wistar_ubuntu_16_pb.yml
+++ b/extras/install_wistar_ubuntu_16_pb.yml
@@ -132,9 +132,16 @@
       state: directory
       recurse: yes
 
-  - name: set permissions on wistar logfile
+  - name: set permissions on wistar errorlog
     file:
-      path: /var/log/wistar.log
+      path: /var/log/apache2/wistar.log
+      owner: www-data
+      group: www-data
+      state: file
+
+  - name: set permissions on wistar accesslog
+    file:
+      path: /var/log/apache2/wistar_access.log
       owner: www-data
       group: www-data
       state: file

--- a/extras/install_wistar_ubuntu_16_pb.yml
+++ b/extras/install_wistar_ubuntu_16_pb.yml
@@ -9,11 +9,14 @@
   become: true
 
   tasks:
+  - name: Update all packages to the latest version
+    apt:
+      upgrade: dist
+      update_cache: yes
   - name: Install Junos-eznc dependancies
     apt:
       name: "{{ item }}"
       state: present
-      update_cache: true
     with_items:
       - build-essential
       - libxml2-dev
@@ -102,13 +105,45 @@
       repo: https://github.com/Juniper/wistar.git
       depth: 1
       dest: /opt/wistar/wistar-app/
-
-  - name: Set up Wistar to run at boot (HACK)
-    lineinfile:
-      create: no
-      dest: /etc/rc.local
-      insertbefore: exit 0
-      line: /opt/wistar/wistar-app/manage.py runserver 0.0.0.0:80 >>/var/log/wistar-stdout.log 2>&1 &
-
+ 
   - name: Create Wistar tables
     command: /opt/wistar/wistar-app/manage.py migrate
+
+  - name: install apache2
+    apt:
+      name: "{{ item }}"
+      state: present
+    with_items:
+      - apache2
+      - libapache2-mod-wsgi
+
+  - name: enable the Apache2 module "wsgi"
+    apache2_module:
+      state: present
+      name: wsgi
+    notify: restart apache
+
+  - name: set permissions on wistar dir
+    file:
+      path: /opt/wistar
+      owner: www-data
+      group: www-data
+      state: directory
+      recurse: yes
+
+  - name: set permissions on wistar logfile
+    file:
+      path: /var/log/wistar.log
+      owner: www-data
+      group: www-data
+      state: file
+
+  - name: copy wistar config file to apache
+    copy:
+      src: 999-wistar.conf
+      dest: /etc/apache2/sites-enabled/999-wistar.conf
+    notify: restart apache
+
+  handlers:
+    - name: restart apache
+      service: name=apache2 state=restarted

--- a/extras/install_wistar_ubuntu_16_pb.yml
+++ b/extras/install_wistar_ubuntu_16_pb.yml
@@ -13,6 +13,7 @@
     apt:
       upgrade: dist
       update_cache: yes
+
   - name: Install Junos-eznc dependancies
     apt:
       name: "{{ item }}"
@@ -85,7 +86,7 @@
       state: directory
   - name: Create Wistar directory structure 3
     file:
-      path: /opt/wistar/wistar-app
+      path: /opt/wistar/wistar-master
       state: directory
   - name: Create Wistar directory structure 4
     file:
@@ -104,10 +105,10 @@
     git:
       repo: https://github.com/Juniper/wistar.git
       depth: 1
-      dest: /opt/wistar/wistar-app/
+      dest: /opt/wistar/wistar-master/
  
   - name: Create Wistar tables
-    command: /opt/wistar/wistar-app/manage.py migrate
+    command: /opt/wistar/wistar-master/manage.py migrate
 
   - name: install apache2
     apt:

--- a/extras/install_wistar_ubuntu_16_pb.yml
+++ b/extras/install_wistar_ubuntu_16_pb.yml
@@ -144,6 +144,12 @@
       dest: /etc/apache2/sites-enabled/999-wistar.conf
     notify: restart apache
 
+  - name: add www-data to libvirt users
+    user:
+      name: www-data
+      groups: libvirtd
+      append: yes
+
   handlers:
     - name: restart apache
       service: name=apache2 state=restarted


### PR DESCRIPTION
There are some errors in the README with regards to configuring Apache2 to serve the Wistar webinterface:

- path in Apache2 config is wrong
- permissions for www-data user need to be set on wistar directory and logfiles

In addition, I've added Apache2 configuration to the Ansible playbooks instead of hack to use runserver at boot.